### PR TITLE
Update README.md to use validate() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $otpCounter = $userObject->getOTPCounter();
 $providedOTP = $requestObject->getPost('otp');
 
 $otplib = new HOTP($otpSeed);
-if ($otplib->verify($providedOTP, $otpCounter)) {
+if ($otplib->validate($providedOTP, $otpCounter)) {
     // Advance the application's stored counter
     // This bit is important for HOTP but not done for TOTP
     $userObject->incrementOTPCounter($otplib->getLastValidCounterOffset() + 1);


### PR DESCRIPTION
The `verify()` function appears to have been renamed to `validate()`. Update the README.md to reflect this change.
