### PR TITLE
Fix issue with fast-expiring TOTP tokens

### DIFF
--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -27,7 +27,7 @@ class TOTP extends HOTP
     public function __construct($secret, array $options = array ())
     {
         $options = array_merge(array (
-                'window' => 0,
+                'window' => 1,
                 'timestep' => 30,
             ), array_change_key_case($options, CASE_LOWER)
         );
@@ -88,7 +88,7 @@ class TOTP extends HOTP
 
         $valid = false;
         $offset = null;
-        $counterLow = max(0, $counter - intval(floor($window / 2)));
+        $counterLow = max(0, $counter - intval(ceil($window / 2)));
         $counterHigh = max(0, $counter + intval(ceil($window / 2)));
         for ($current = $counterLow; $current <= $counterHigh; ++$current) {
             if ($otp === parent::calculate($current)) {


### PR DESCRIPTION
When a TOTP token is generated in the last second of a time-step it invalidates a second later. Practically, that makes validating a TOTP very difficult, especially because windowing only goes forward in this implementation.

According to RFC 6238:

> When an OTP is generated at the end of a time-step window, the receiving time most likely falls into the next time-step window.  A validation system SHOULD typically set a policy for an acceptable OTP transmission delay window for validation.  The validation system should compare OTPs not only with the receiving timestamp but also the past timestamps that are within the transmission delay.  A larger acceptable delay window would expose a larger window for attacks.  We RECOMMEND that at most one time step is allowed as the network delay.

This commit fixes that issue, first by allowing the validation function to check one time-step window back (the `$counterLow` value was always the CURRENT time-step), and second by making a window of 1 default.
